### PR TITLE
Auto push config on venue change and capabilities message.

### DIFF
--- a/src/AutoDiscovery.cpp
+++ b/src/AutoDiscovery.cpp
@@ -5,6 +5,7 @@
 #include "AutoDiscovery.h"
 #include "Poco/JSON/Parser.h"
 #include "StorageService.h"
+#include "Tasks/VenueConfigUpdater.h"
 #include "framework/KafkaManager.h"
 #include "framework/KafkaTopics.h"
 #include "framework/ow_constants.h"
@@ -107,6 +108,11 @@ namespace OpenWifi {
                         if (!SerialNumber.empty() && Connected) {
                             StorageService()->InventoryDB().CreateFromConnection(
                                     SerialNumber, ConnectedIP, Compatible, Locale, isConnection);
+                            // Now that the entry has been created, we can try to push a config if
+                            // the connection was a capabilities message.
+                            if (isConnection){
+                                ComputeAndPushConfig(SerialNumber, Compatible, Logger());
+                            }
                         }
                     }
 				} catch (const Poco::Exception &E) {


### PR DESCRIPTION
Note: The removed code (GetRejectedLines) is because the exact same function (with the same code) is defined in VenueConfigUpdater.h so when you import that header file it creates a conflict and the build fails.