### PR TITLE
Implement simple RBAC with whitelist

### DIFF
--- a/src/RESTAPI/RESTAPI_entity_handler.cpp
+++ b/src/RESTAPI/RESTAPI_entity_handler.cpp
@@ -32,11 +32,6 @@ namespace OpenWifi {
 	}
 
 	void RESTAPI_entity_handler::DoDelete() {
-		/*
-		if (!UserInfo_.userinfo.userPermissions[SecurityObjects::PM_ENTITIES_PROV][SecurityObjects::PT_DELETE]) {
-			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
-		}
-		*/
 
 		std::string UUID = GetBinding("uuid", "");
 		ProvObjects::Entity Existing;
@@ -62,11 +57,6 @@ namespace OpenWifi {
 	}
 
 	void RESTAPI_entity_handler::DoPost() {
-		/*
-		if (!UserInfo_.userinfo.userPermissions[SecurityObjects::PM_ENTITIES_PROV][SecurityObjects::PT_CREATE]) {
-			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
-		}
-		*/
 
 		std::string UUID = GetBinding("uuid", "");
 		if (UUID.empty()) {

--- a/src/RESTAPI/RESTAPI_entity_handler.cpp
+++ b/src/RESTAPI/RESTAPI_entity_handler.cpp
@@ -32,9 +32,11 @@ namespace OpenWifi {
 	}
 
 	void RESTAPI_entity_handler::DoDelete() {
+		/*
 		if (!UserInfo_.userinfo.userPermissions[SecurityObjects::PM_ENTITIES_PROV][SecurityObjects::PT_DELETE]) {
 			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
 		}
+		*/
 
 		std::string UUID = GetBinding("uuid", "");
 		ProvObjects::Entity Existing;
@@ -60,9 +62,11 @@ namespace OpenWifi {
 	}
 
 	void RESTAPI_entity_handler::DoPost() {
+		/*
 		if (!UserInfo_.userinfo.userPermissions[SecurityObjects::PM_ENTITIES_PROV][SecurityObjects::PT_CREATE]) {
 			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
 		}
+		*/
 
 		std::string UUID = GetBinding("uuid", "");
 		if (UUID.empty()) {

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -79,9 +79,11 @@ namespace OpenWifi {
 	}
 
 	void RESTAPI_venue_handler::DoDelete() {
+		/*
 		if (!UserInfo_.userinfo.userPermissions[SecurityObjects::PM_VENUES_PROV][SecurityObjects::PT_DELETE]) {
 			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
 		}
+		*/
 
 		std::string UUID = GetBinding("uuid", "");
 		ProvObjects::Venue Existing;
@@ -121,9 +123,11 @@ namespace OpenWifi {
 	}
 
 	void RESTAPI_venue_handler::DoPost() {
+		/*
 		if (!UserInfo_.userinfo.userPermissions[SecurityObjects::PM_VENUES_PROV][SecurityObjects::PT_CREATE]) {
 			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
 		}
+		*/
 
 		std::string UUID = GetBinding("uuid", "");
 		if (UUID.empty()) {

--- a/src/RESTAPI/RESTAPI_venue_handler.cpp
+++ b/src/RESTAPI/RESTAPI_venue_handler.cpp
@@ -79,11 +79,6 @@ namespace OpenWifi {
 	}
 
 	void RESTAPI_venue_handler::DoDelete() {
-		/*
-		if (!UserInfo_.userinfo.userPermissions[SecurityObjects::PM_VENUES_PROV][SecurityObjects::PT_DELETE]) {
-			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
-		}
-		*/
 
 		std::string UUID = GetBinding("uuid", "");
 		ProvObjects::Venue Existing;
@@ -123,11 +118,6 @@ namespace OpenWifi {
 	}
 
 	void RESTAPI_venue_handler::DoPost() {
-		/*
-		if (!UserInfo_.userinfo.userPermissions[SecurityObjects::PM_VENUES_PROV][SecurityObjects::PT_CREATE]) {
-			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
-		}
-		*/
 
 		std::string UUID = GetBinding("uuid", "");
 		if (UUID.empty()) {

--- a/src/RESTObjects/RESTAPI_SecurityObjects.h
+++ b/src/RESTObjects/RESTAPI_SecurityObjects.h
@@ -11,16 +11,21 @@
 #include "Poco/Data/LOB.h"
 #include "Poco/Data/LOBStream.h"
 #include "Poco/JSON/Object.h"
+#include "Poco/Net/HTTPRequest.h"
 #include "framework/OpenWifiTypes.h"
 #include "framework/utils.h"
 #include <string>
 #include <type_traits>
 #include <iostream>
 #include <fstream>
+#include <map>
+#include <set>
 
 namespace OpenWifi {
 	uint64_t Now();
 	namespace SecurityObjects {
+
+
 
 		typedef std::string USER_ID_TYPE;
 
@@ -55,6 +60,13 @@ namespace OpenWifi {
 
 			void to_json(Poco::JSON::Object &Obj) const;
 			bool from_json(const Poco::JSON::Object::Ptr &Obj);
+		};
+
+		const std::map<std::string, std::set<std::string>> API_WHITELIST = {
+			{"/api/v1/venue", {Poco::Net::HTTPRequest::HTTP_POST, Poco::Net::HTTPRequest::HTTP_PUT, Poco::Net::HTTPRequest::HTTP_DELETE}},
+			{"/api/v1/inventory", {Poco::Net::HTTPRequest::HTTP_POST, Poco::Net::HTTPRequest::HTTP_PUT, Poco::Net::HTTPRequest::HTTP_DELETE}},
+			{"/api/v1/variable", {Poco::Net::HTTPRequest::HTTP_POST, Poco::Net::HTTPRequest::HTTP_PUT, Poco::Net::HTTPRequest::HTTP_DELETE}},
+			{"/api/v1/configuration", {Poco::Net::HTTPRequest::HTTP_POST, Poco::Net::HTTPRequest::HTTP_PUT, Poco::Net::HTTPRequest::HTTP_DELETE}}
 		};
 
 		enum USER_ROLE {

--- a/src/framework/RESTAPI_Handler.h
+++ b/src/framework/RESTAPI_Handler.h
@@ -59,10 +59,49 @@ namespace OpenWifi {
 			  Internal_(Internal), RateLimited_(RateLimited), SubOnlyService_(SubscriberOnly),
 			  AlwaysAuthorize_(AlwaysAuthorize), Server_(Server), MyRates_(Profile),
 			  TransactionId_(TransactionId) {}
+		
+		inline int nthOccurrence(const std::string& str, const std::string& findMe, int nth) {
+			size_t  pos = 0;
+			int     count = 0;
+
+			while( count != nth )
+			{
+				pos+=1;
+				pos = str.find(findMe, pos);
+				if ( pos == std::string::npos )
+					return -1;
+				count++;
+			}
+			return pos;
+		}
 
 		inline bool RoleIsAuthorized([[maybe_unused]] const std::string &Path,
 									 [[maybe_unused]] const std::string &Method,
 									 [[maybe_unused]] std::string &Reason) {
+			// If user role is admin or root, authorized is true
+			if (UserInfo_.userinfo.userRole == SecurityObjects::USER_ROLE::ADMIN || UserInfo_.userinfo.userRole == SecurityObjects::USER_ROLE::ROOT) {
+				return true;
+			}
+			
+			// We just want the /api/v1/x part of the path so we need to account for
+			// extra path variables as well as query variables.
+			std::string pathstubtmp = Path.substr(0, nthOccurrence(Path, "/", 3));
+			std::string pathstub = pathstubtmp.substr(0, nthOccurrence(pathstubtmp, "?", 1));
+
+			// Next check the pathstub against the whitelist
+			if (SecurityObjects::API_WHITELIST.find(pathstub) != SecurityObjects::API_WHITELIST.end()) {
+				std::set<std::string> allowed_methods = SecurityObjects::API_WHITELIST.at(pathstub);
+				// The API stub is in the whitelist, but we also need to check that this method is whitelisted for this stub.
+				if (allowed_methods.find(Method) != allowed_methods.end()) {
+					return true;
+				}
+			}
+
+			// At this point, the user is not root/admin and the API + method is not whitelisted, so we disallow any method that is not a GET.
+			if (Method != Poco::Net::HTTPRequest::HTTP_GET) {
+				return false;
+			}
+			
 			return true;
 		}
 
@@ -101,6 +140,7 @@ namespace OpenWifi {
 				}
 
 				std::string Reason;
+				
 				if (!RoleIsAuthorized(RequestIn.getURI(), Request->getMethod(), Reason)) {
 					return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
 				}

--- a/src/framework/RESTAPI_Handler.h
+++ b/src/framework/RESTAPI_Handler.h
@@ -61,6 +61,10 @@ namespace OpenWifi {
 			  TransactionId_(TransactionId) {}
 		
 		inline int nthOccurrence(const std::string& str, const std::string& findMe, int nth) {
+			/*
+			Helper function to get the index of the nth occurence of string findMe in string str.
+			if there are not n occurrences of findMe in str, returns -1.
+			*/
 			size_t  pos = 0;
 			int     count = 0;
 

--- a/src/framework/RESTAPI_Handler.h
+++ b/src/framework/RESTAPI_Handler.h
@@ -68,11 +68,11 @@ namespace OpenWifi {
 			size_t  pos = 0;
 			int     count = 0;
 
-			while( count != nth )
+			while(count != nth)
 			{
 				pos+=1;
 				pos = str.find(findMe, pos);
-				if ( pos == std::string::npos )
+				if (pos == std::string::npos)
 					return -1;
 				count++;
 			}


### PR DESCRIPTION
**Description:**
Non-admin/root users should not be able to make PUT, POST, or DELETE API calls to any endpoint unless that endpoint and the corresponding method are in the whitelist.
Note: this is not meant to be upstreamed.

**Trello link:**
https://trello.com/c/aHR4imbk/436-owprov-simple-rbac-with-whitelist

**Summary of Changes:**
- Old RBAC code done by Tony commented out as it was blocking this change (entity handler and venue handler)
- RoleIsAuthorized function implemented to perform role and whitelist check - this function was previously unused (always returned true) so this seemed like the correct place to put RBAC logic
- static whitelist created to map allowed API endpoints and HTTP verbs.

